### PR TITLE
fix: remove property deprecated for flutter version 3.32.

### DIFF
--- a/lib/src/input_decoration.dart
+++ b/lib/src/input_decoration.dart
@@ -131,7 +131,6 @@ class SearchInputDecoration extends InputDecoration {
     super.errorMaxLines,
     super.errorStyle,
     super.suffixIconConstraints,
-    super.visualDensity,
   });
 
   @override
@@ -276,7 +275,6 @@ class SearchInputDecoration extends InputDecoration {
       suffixIconColor: suffixIconColor ?? this.suffixIconColor,
       suffixStyle: suffixStyle ?? this.suffixStyle,
       suffixText: suffixText ?? this.suffixText,
-      visualDensity: visualDensity ?? this.visualDensity,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: searchfield
 description: A highly customizable, simple and easy to use AutoComplete widget for your Flutter app
-version: 1.3.4
+version: 1.3.5
 homepage: https://github.com/maheshj01/searchfield
 repository: https://github.com/maheshj01/searchfield
 issue_tracker: https://github.com/maheshj01/searchfield/issues


### PR DESCRIPTION
This PR fixes a build error when compiling for Flutter 3.32.6 or newer.
The ```SearchInputDecoration``` class was incorrectly using ```super.visualDensity```, which is no longer supported in the constructor of ```InputDecoration``` in recent versions of Flutter.
This caused web builds (e.g. using ```flutter build web```) to fail with the following error:

```js
Error: The super constructor has no corresponding named parameter.
    super.visualDensity,

```

Fixes: Build failure when using Flutter 3.32.6+

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshj01

<!-- Links -->
[Contributor Guide]: https://github.com/maheshj01/searchfield/blob/master/CONTRIBUTING.md